### PR TITLE
fix: allow chat admins to cancel scheduled tasks

### DIFF
--- a/src/main/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandler.java
+++ b/src/main/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandler.java
@@ -1,12 +1,15 @@
 package ru.javazen.telegram.bot.scheduler;
 
+import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatAdministrators;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.bots.AbsSender;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import ru.javazen.telegram.bot.handler.base.TextMessageHandler;
 import ru.javazen.telegram.bot.scheduler.service.MessageSchedulerService;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 public class UnschedulerNotifyHandler implements TextMessageHandler {
@@ -22,7 +25,7 @@ public class UnschedulerNotifyHandler implements TextMessageHandler {
 
     @Override
     public boolean handle(Message message, String text, AbsSender sender) throws TelegramApiException {
-        if (!message.isReply() || !isReplyAuthor(message)) {
+        if (!message.isReply() || !canCancelTask(message, sender)) {
             return false;
         }
 
@@ -39,8 +42,22 @@ public class UnschedulerNotifyHandler implements TextMessageHandler {
         return canceled;
     }
 
+    private boolean canCancelTask(Message message, AbsSender sender) throws TelegramApiException {
+        return isReplyAuthor(message) || isChatAdmin(message, sender);
+    }
+
     private boolean isReplyAuthor(Message message) {
         return message.getFrom().getId().equals(message.getReplyToMessage().getFrom().getId());
+    }
+
+    private boolean isChatAdmin(Message message, AbsSender sender) throws TelegramApiException {
+        GetChatAdministrators getChatAdministrators = new GetChatAdministrators();
+        getChatAdministrators.setChatId(message.getChatId());
+
+        List<ChatMember> administrators = sender.execute(getChatAdministrators);
+        return administrators.stream()
+                .map(ChatMember::getUser)
+                .anyMatch(user -> message.getFrom().getId().equals(user.getId()));
     }
 }
 

--- a/src/test/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandlerTest.java
+++ b/src/test/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandlerTest.java
@@ -1,0 +1,108 @@
+package ru.javazen.telegram.bot.scheduler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatAdministrators;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
+import org.telegram.telegrambots.meta.bots.AbsSender;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import ru.javazen.telegram.bot.scheduler.service.MessageSchedulerService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UnschedulerNotifyHandlerTest {
+
+    private static final Long CHAT_ID = 222L;
+    private static final Integer TASK_MESSAGE_ID = 333;
+
+    private UnschedulerNotifyHandler handler;
+
+    @Mock
+    private MessageSchedulerService messageSchedulerService;
+
+    @Mock
+    private AbsSender sender;
+
+    @Mock
+    private Message message;
+
+    @Mock
+    private Message replyToMessage;
+
+    @Before
+    public void init() {
+        handler = new UnschedulerNotifyHandler(messageSchedulerService, () -> "ok");
+
+        when(message.isReply()).thenReturn(true);
+        when(message.getChatId()).thenReturn(CHAT_ID);
+        when(message.getReplyToMessage()).thenReturn(replyToMessage);
+        when(replyToMessage.getMessageId()).thenReturn(TASK_MESSAGE_ID);
+    }
+
+    @Test
+    public void replyAuthorCanCancelTask() throws TelegramApiException {
+        setMessageAuthor(111L);
+        setReplyAuthor(111L);
+        when(messageSchedulerService.cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID)).thenReturn(true);
+
+        assertTrue(handler.handle(message, "", sender));
+
+        verify(messageSchedulerService).cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID);
+        verify(sender, never()).execute(any(GetChatAdministrators.class));
+    }
+
+    @Test
+    public void chatAdminCanCancelAnotherAuthorTask() throws TelegramApiException {
+        setMessageAuthor(111L);
+        setReplyAuthor(999L);
+        when(sender.execute(any(GetChatAdministrators.class))).thenReturn(new ArrayList<>(List.of(admin(111L))));
+        when(messageSchedulerService.cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID)).thenReturn(true);
+
+        assertTrue(handler.handle(message, "", sender));
+
+        verify(messageSchedulerService).cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID);
+    }
+
+    @Test
+    public void nonAdminCanNotCancelAnotherAuthorTask() throws TelegramApiException {
+        setMessageAuthor(111L);
+        setReplyAuthor(999L);
+        when(sender.execute(any(GetChatAdministrators.class))).thenReturn(new ArrayList<>());
+
+        assertFalse(handler.handle(message, "", sender));
+
+        verify(messageSchedulerService, never()).cancelTaskByChatAndMessage(anyLong(), anyInt());
+    }
+
+    private void setMessageAuthor(Long userId) {
+        when(message.getFrom()).thenReturn(user(userId));
+    }
+
+    private void setReplyAuthor(Long userId) {
+        when(replyToMessage.getFrom()).thenReturn(user(userId));
+    }
+
+    private ChatMember admin(Long userId) {
+        ChatMember admin = mock(ChatMember.class);
+        when(admin.getUser()).thenReturn(user(userId));
+        return admin;
+    }
+
+    private User user(Long id) {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(id);
+        return user;
+    }
+}


### PR DESCRIPTION
### Motivation
- Existing behavior allowed only the original author of a scheduled (reply) message to cancel it, which prevented chat administrators from stopping reminders created by others.
- Enable administrators to cancel scheduled reminder tasks to simplify moderation and control over chats.

### Description
- Extended `UnschedulerNotifyHandler` to check `canCancel(message, sender)` which permits cancellation when the replier is the original author or a chat admin.
- Implemented `isChatAdmin` using `GetChatAdministrators` and checking returned `ChatMember` users against the requestor's id.
- Added unit tests in `UnschedulerNotifyHandlerTest` covering three scenarios: author cancels (no admin lookup), chat admin cancels another user's task, and non-admin cannot cancel another user's task.

### Testing
- Attempted to run the new test class with `mvn -q -Dtest=UnschedulerNotifyHandlerTest test`, but the run failed because Maven could not resolve the parent POM `org.springframework.boot:spring-boot-starter-parent:pom:3.5.9` from Maven Central (HTTP 403), so unit tests could not be executed in this environment.
- Local static checks (`git diff --check`) passed during the change preparation.