### PR TITLE
fix: unscheduler private chat cancellation

### DIFF
--- a/src/main/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandler.java
+++ b/src/main/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandler.java
@@ -2,6 +2,7 @@ package ru.javazen.telegram.bot.scheduler;
 
 import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatAdministrators;
 import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.bots.AbsSender;
@@ -51,6 +52,11 @@ public class UnschedulerNotifyHandler implements TextMessageHandler {
     }
 
     private boolean isChatAdmin(Message message, AbsSender sender) throws TelegramApiException {
+        Chat chat = message.getChat();
+        if (chat != null && chat.isUserChat()) {
+            return true;
+        }
+
         GetChatAdministrators getChatAdministrators = new GetChatAdministrators();
         getChatAdministrators.setChatId(message.getChatId());
 

--- a/src/test/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandlerTest.java
+++ b/src/test/java/ru/javazen/telegram/bot/scheduler/UnschedulerNotifyHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.telegram.telegrambots.meta.api.methods.groupadministration.GetChatAdministrators;
+import org.telegram.telegrambots.meta.api.objects.Chat;
 import org.telegram.telegrambots.meta.api.objects.Message;
 import org.telegram.telegrambots.meta.api.objects.User;
 import org.telegram.telegrambots.meta.api.objects.chatmember.ChatMember;
@@ -76,6 +77,19 @@ public class UnschedulerNotifyHandlerTest {
     }
 
     @Test
+    public void personalChatUserCanCancelAnotherAuthorTask() throws TelegramApiException {
+        setMessageAuthor(111L);
+        setReplyAuthor(999L);
+        setPersonalChat();
+        when(messageSchedulerService.cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID)).thenReturn(true);
+
+        assertTrue(handler.handle(message, "", sender));
+
+        verify(messageSchedulerService).cancelTaskByChatAndMessage(CHAT_ID, TASK_MESSAGE_ID);
+        verify(sender, never()).execute(any(GetChatAdministrators.class));
+    }
+
+    @Test
     public void nonAdminCanNotCancelAnotherAuthorTask() throws TelegramApiException {
         setMessageAuthor(111L);
         setReplyAuthor(999L);
@@ -84,6 +98,12 @@ public class UnschedulerNotifyHandlerTest {
         assertFalse(handler.handle(message, "", sender));
 
         verify(messageSchedulerService, never()).cancelTaskByChatAndMessage(anyLong(), anyInt());
+    }
+
+    private void setPersonalChat() {
+        Chat chat = mock(Chat.class);
+        when(chat.isUserChat()).thenReturn(true);
+        when(message.getChat()).thenReturn(chat);
     }
 
     private void setMessageAuthor(Long userId) {


### PR DESCRIPTION
Fixed UnschedulerNotifyHandler so private/personal chats are treated as allowed to cancel without calling Telegram’s group-admin API; isChatAdmin now returns true for chat.isUserChat(). 

Added a regression test for personal chats verifying a user can cancel a replied scheduled task from another author and that GetChatAdministrators is not called. 

Added a test helper that mocks Telegram Chat#isUserChat() as true for the personal-chat scenario. 

Committed changes on the current branch: 60f8cc1 Fix unscheduler private chat cancellation.

Created a pull request: Fix unscheduler cancellation in private chats.